### PR TITLE
Malformed JSON API fix

### DIFF
--- a/alpaca-server/alpaca-server.js
+++ b/alpaca-server/alpaca-server.js
@@ -137,8 +137,8 @@ class AlpacaServer{
                 responseObj['cardpile_cards'] = this.alpacaGame.cardpile.length;                
             }else{
                 var statusObject = this.alpacaGame.getPlayerStatus(joinedPlayer.id);
-                var anonymObject = {};
-                anonymObject[joinedPlayer.name] = {
+                var anonymObject = {
+		    player_name: joinedPlayer.name,
                     hand_cards: statusObject.hand.length,
                     coins: statusObject.coins,
                     score: statusObject.score,


### PR DESCRIPTION
In the game status response the `other_players` array is useless in statically typed language since it uses the dynamic player name as the name of a field. This makes it impossible (at least without manual JSON text parsing effort) to map onto a struct/class field. This also is not good practice for an external API.

Instead the player name should be included inside the player object to make the objects inside the array uniform and mappable onto a static struct/class.